### PR TITLE
feat: docker socket is configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,12 @@ Ducker is configured via a yaml file found in the relevant config directory for 
 
 The following table summarises the available config values:
 
-| Key          | Default     | Description                                                                                                                 |
-| ------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
-| prompt       | 🦆           | The default prompt to display in the command pane                                                                           |
-| default_exec | `/bin/bash` | The default prompt to display in the command pane. NB - currently uses this for all exec's; it is planned to offer a choice |
-| theme        | [See below] | The colour theme configuration                                                                                              |
+| Key          | Default                       | Description                                                                                                                 |
+| ------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| prompt       | 🦆                             | The default prompt to display in the command pane                                                                           |
+| default_exec | `/bin/bash`                   | The default prompt to display in the command pane. NB - currently uses this for all exec's; it is planned to offer a choice |
+| docker_path  | `unix:///var/run/docker.sock` | The location of the socket on which the docker daemon is exposed (defaults to `npipe:////./pipe/docker_engine` on windows)  |
+| theme        | [See below]                   | The colour theme configuration                                                                                              |
 
 If a value is unset or if the config file is unfound, Ducker will use the default values.  If a value is malformed, Ducker will fail to run.
 

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,3 +1,4 @@
 pub mod container;
 pub mod image;
 pub mod logs;
+pub mod util;

--- a/src/docker/util.rs
+++ b/src/docker/util.rs
@@ -1,0 +1,14 @@
+use bollard::{Docker, API_DEFAULT_VERSION};
+use color_eyre::eyre::{Context, Result};
+
+use super::container::DockerContainer;
+
+pub async fn new_local_docker_connection(socket_path: &str) -> Result<Docker> {
+    let docker = bollard::Docker::connect_with_socket(socket_path, 120, API_DEFAULT_VERSION)
+        .with_context(|| "unable to connect to local docker socket")?;
+
+    DockerContainer::list(&docker)
+        .await
+        .context("unable to connect to local docker socket")?;
+    Ok(docker)
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,3 +1,4 @@
+use bollard::Docker;
 use color_eyre::eyre::{Context, Result};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
@@ -42,12 +43,16 @@ pub struct App {
 }
 
 impl App {
-    pub async fn new(tx: Sender<Message<Key, Transition>>, config: Config) -> Result<Self> {
+    pub async fn new(
+        tx: Sender<Message<Key, Transition>>,
+        docker: Docker,
+        config: Config,
+    ) -> Result<Self> {
         let config = Box::new(config);
 
         let page = state::CurrentPage::default();
 
-        let body = PageManager::new(page.clone(), tx.clone(), config.clone())
+        let body = PageManager::new(page.clone(), tx.clone(), docker, config.clone())
             .await
             .context("unable to create new body component")?;
 

--- a/src/ui/page_manager.rs
+++ b/src/ui/page_manager.rs
@@ -29,11 +29,9 @@ impl PageManager {
     pub async fn new(
         page: state::CurrentPage,
         tx: Sender<Message<Key, Transition>>,
+        docker: Docker,
         config: Box<Config>,
     ) -> Result<Self> {
-        let docker = bollard::Docker::connect_with_socket_defaults()
-            .context("unable to connect to local docker daemon")?;
-
         let containers = Box::new(Containers::new(docker.clone(), tx.clone(), config.clone()));
 
         let mut page_manager = Self {


### PR DESCRIPTION
- docker-path cli arg
- default config with original/current config
- can override in config

Implements:
Suppot for different docker.sock location  #19