### PR TITLE
refactor(pages): simplify page lifecycle removing the redundant concept of visibility

### DIFF
--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -5,4 +5,5 @@ mod page;
 pub use callback::Callback;
 pub use component::Component;
 pub use component::ModalComponent;
+pub use page::Close;
 pub use page::Page;

--- a/src/traits/page.rs
+++ b/src/traits/page.rs
@@ -14,10 +14,15 @@ use crate::{
 };
 
 #[async_trait]
-pub trait Page: Component + Debug + Send + Sync {
+pub trait Page: Component + Close + Debug + Send + Sync {
     async fn update(&mut self, message: Key) -> Result<MessageResponse>;
-    async fn initialise(&mut self) -> Result<()>;
-    async fn set_visible(&mut self, cx: AppContext) -> Result<()>;
-    async fn set_invisible(&mut self) -> Result<()>;
+    async fn initialise(&mut self, cx: AppContext) -> Result<()>;
     fn get_help(&self) -> Arc<Mutex<PageHelp>>;
+}
+
+#[async_trait]
+pub trait Close: Debug + Send + Sync {
+    async fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/ui/page_manager.rs
+++ b/src/ui/page_manager.rs
@@ -51,7 +51,7 @@ impl PageManager {
     }
 
     pub async fn init(&mut self) -> Result<()> {
-        self.page.set_visible(AppContext::default()).await?;
+        self.page.initialise(AppContext::default()).await?;
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl PageManager {
             return Ok(());
         }
         self.page
-            .set_invisible()
+            .close()
             .await
             .context("unable to close old page")?;
 
@@ -124,7 +124,7 @@ impl PageManager {
         };
 
         self.page
-            .set_visible(cx)
+            .initialise(cx)
             .await
             .context("unable to open new page")?;
 

--- a/src/widgets/modal.rs
+++ b/src/widgets/modal.rs
@@ -82,6 +82,6 @@ impl<'a> Widget for ModalWidget<'a> {
 
         self.prompt.wrap(Wrap { trim: true }).render(top, buf);
 
-        Line::from(self.opts).centered().render(bottom, buf)
+        Line::from(self.opts).centered().render(bottom, buf);
     }
 }


### PR DESCRIPTION
- In the first pass of the Containers and Images pages, there was a concept of "visibility"; this was before the Page trait had been added

- This removes the concept of visibility (and the corrolorary call to `initialise`

- Instead there is a single `initialise` method

- Where clean-up is required for a page, there is a `Close` trait that must be implemented by all Pages

- The close method has a default behaviour, this could go in a simple procedural macro with time but for now it just falls back on the default behaviour where no clean-up is requried for the page