### PR TITLE
add brew commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ You can install `ducker` from the [AUR](https://aur.archlinux.org/packages/ducke
 paru -S ducker
 ```
 
+### Brew
+
+For macOS, you can install `ducker` using by `homebrew`.
+
+```sh
+brew tap draftbrew/tap
+brew install ducker
+```
+
 ### Unstable
 
 To install the latest unstable version of Ducker, run the following command:


### PR DESCRIPTION
I have moved my own homebrew tap to the organization DraftBrew for more public one.
By using this custom tap, it is much simpler to install `ducker` on macOS.

First, add the custom tap at once
```sh
brew tap draftbrew/tap
```
and then install the package.
```sh
brew install ducker
```

Then, it will download ducker source and install rust, build with cargo, register bin to path automatically.
I think it is also possible to use homebrew on linux but I have never tried.

The reason why I am registering this to the custom tap is the minumum requirements.

- be maintained (i.e. the last release wasn’t ages ago, it works without patching on all Homebrew-supported OS versions and has no outstanding, unpatched security vulnerabilities)
- be stable (e.g. not declared “unstable” or “beta” by upstream)
- be known (e.g. GitHub repositories should have >=30 forks, >=30 watchers or >=75 stars)
- be used
- have a homepage

Once the project ready for that, I will submit the official formula to the homebrew-core and will migrate the custom one to the official one.