### PR TITLE
feat: initial choice of exec command

### DIFF
--- a/src/components/text_input_wrapper.rs
+++ b/src/components/text_input_wrapper.rs
@@ -36,7 +36,7 @@ impl TextInputWrapper {
         Ok(MessageResponse::Consumed)
     }
 
-    pub fn get_value(&mut self) -> String {
+    pub fn get_value(&self) -> String {
         self.state.get_value().clone()
     }
 

--- a/src/pages/attach.rs
+++ b/src/pages/attach.rs
@@ -2,13 +2,17 @@ use std::sync::{Arc, Mutex};
 
 use crossterm::terminal::disable_raw_mode;
 
-use color_eyre::eyre::{bail, Ok, Result};
+use color_eyre::eyre::{bail, Result};
+use ratatui::layout::{Constraint, Layout};
 use ratatui::{layout::Rect, Frame};
 use tokio::sync::mpsc::Sender;
 
+use crate::components::alert_modal::{AlertModal, ModalState};
+use crate::components::text_input_wrapper::TextInputWrapper;
 use crate::config::Config;
 use crate::context::AppContext;
-use crate::traits::Close;
+use crate::docker::traits::Describe;
+use crate::traits::{Close, ModalComponent};
 use crate::{
     components::help::{PageHelp, PageHelpBuilder},
     docker::container::DockerContainer,
@@ -17,70 +21,132 @@ use crate::{
 };
 
 const NAME: &str = "Attach";
+const PROMPT: &str = "exec: ";
 
 const ESC_KEY: Key = Key::Esc;
+const ENTER: Key = Key::Enter;
+
+#[derive(Debug)]
+enum ModalType {
+    AlertModal,
+}
 
 #[derive(Debug)]
 pub struct Attach {
     config: Box<Config>,
     container: Option<DockerContainer>,
+    next: Option<Transition>,
     tx: Sender<Message<Key, Transition>>,
     page_help: Arc<Mutex<PageHelp>>,
+    attach_input: TextInputWrapper,
+    alert_modal: AlertModal<ModalType>,
 }
 
 impl Attach {
     pub fn new(tx: Sender<Message<Key, Transition>>, config: Box<Config>) -> Self {
-        let page_help = PageHelpBuilder::new(NAME.into(), config.clone())
-            .add_input(format!("{ESC_KEY}"), "back".into())
-            .build();
-
+        let page_help = Self::build_page_help(config.clone(), None);
         Self {
             config,
             container: None,
+            next: None,
             tx,
             page_help: Arc::new(Mutex::new(page_help)),
+            attach_input: TextInputWrapper::new(PROMPT.into(), None),
+            alert_modal: AlertModal::new("Error".into(), ModalType::AlertModal),
         }
     }
 
-    async fn attach(&self, container: DockerContainer, exec: &str, cx: AppContext) -> Result<()> {
-        disable_raw_mode()?;
-        container.attach(exec).await?;
+    pub fn build_page_help(config: Box<Config>, name: Option<String>) -> PageHelp {
+        PageHelpBuilder::new(
+            match name {
+                Some(n) => n,
+                None => NAME.into(),
+            },
+            config.clone(),
+        )
+        .add_input(format!("{ESC_KEY}"), "back".into())
+        .add_input(format!("{ENTER}"), "exec".into())
+        .build()
+    }
 
-        let transition = if let Some(t) = cx.next() {
-            t
+    async fn to_containers(&self) -> Result<()> {
+        let transition = if let Some(t) = &self.next {
+            t.clone()
         } else {
-            Transition::ToContainerPage(AppContext {
-                docker_container: Some(container),
-                ..Default::default()
-            })
+            Transition::ToContainerPage(AppContext::default())
         };
 
         self.tx.send(Message::Transition(transition)).await?;
         self.tx
             .send(Message::Transition(Transition::ToNewTerminal))
             .await?;
+
+        Ok(())
+    }
+
+    async fn attach(&self, exec: &str) -> Result<()> {
+        if self.container.is_none() {
+            bail!("could not attach to a container when no container is set");
+        };
+
+        let container = self.container.clone().unwrap();
+
+        disable_raw_mode()?;
+        let res = container.attach(exec).await;
+        self.tx
+            .send(Message::Transition(Transition::ToNewTerminal))
+            .await?;
+
+        if res.is_err() {
+            bail!("failed to attach to container");
+        }
         Ok(())
     }
 }
 
 #[async_trait::async_trait]
 impl Page for Attach {
-    async fn update(&mut self, _message: Key) -> Result<MessageResponse> {
-        let res = MessageResponse::Consumed;
+    async fn update(&mut self, message: Key) -> Result<MessageResponse> {
+        if let ModalState::Open(_) = self.alert_modal.state.clone() {
+            return self.alert_modal.update(message).await;
+        }
 
+        let res = match message {
+            Key::Enter => {
+                let exec = self.attach_input.get_value();
+                match self.attach(&exec).await {
+                    Ok(()) => self.to_containers().await?,
+                    Err(_) => {
+                        let msg = format!("Error in exec with command\n`{exec}`");
+                        self.alert_modal.initialise(msg)
+                    }
+                }
+
+                MessageResponse::Consumed
+            }
+            Key::Esc => {
+                self.to_containers().await?;
+                MessageResponse::Consumed
+            }
+            _ => self.attach_input.update(message)?,
+        };
         Ok(res)
     }
 
     async fn initialise(&mut self, cx: AppContext) -> Result<()> {
         if let Some(container) = cx.clone().docker_container {
+            let page_name = format!("{NAME} ({})", container.get_name());
+            self.page_help = Arc::new(Mutex::new(Self::build_page_help(
+                self.config.clone(),
+                Some(page_name),
+            )));
             self.container = Some(container)
         } else {
             bail!("no docker container")
         }
-        if let Some(container) = self.container.clone() {
-            self.attach(container, &self.config.default_exec, cx)
-                .await?;
-        }
+        self.attach_input
+            .set_input(self.config.default_exec.clone());
+        self.next = cx.next();
         Ok(())
     }
 
@@ -93,5 +159,27 @@ impl Page for Attach {
 impl Close for Attach {}
 
 impl Component for Attach {
-    fn draw(&mut self, _f: &mut Frame<'_>, _area: Rect) {}
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) {
+        let height = area.height;
+
+        let [_, text_area, _] = Layout::vertical([
+            Constraint::Length((height - 3) / 2),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .areas(area);
+
+        let [_, text_area, _] = Layout::horizontal([
+            Constraint::Percentage(5),
+            Constraint::Percentage(90),
+            Constraint::Percentage(5),
+        ])
+        .areas(text_area);
+
+        self.attach_input.draw(f, text_area);
+
+        if let ModalState::Open(_) = self.alert_modal.state.clone() {
+            self.alert_modal.draw(f, area)
+        }
+    }
 }

--- a/src/pages/describe.rs
+++ b/src/pages/describe.rs
@@ -132,7 +132,7 @@ impl Page for DescribeContainer {
             }
         };
         self.thing_summary = Some(thing.describe()?);
-        let page_name = format!("Describe ({})", thing.get_name());
+        let page_name = format!("{NAME} ({})", thing.get_name());
         self.page_help = Arc::new(Mutex::new(Self::build_page_help(
             self.config.clone(),
             Some(page_name),

--- a/src/widgets/text_input.rs
+++ b/src/widgets/text_input.rs
@@ -84,7 +84,7 @@ impl TextInputState {
         self.update_autocomplete();
     }
 
-    pub fn get_value(&mut self) -> String {
+    pub fn get_value(&self) -> String {
         self.value.clone()
     }
 


### PR DESCRIPTION
- First pass at offering user choice as to exec command
- There is an open question as to whether or not to offer a "default exec" action along with a "detailed exec" action
- This also forms the basis of how I might implement the run container feature - though this will need some sort of scrolling
- Also want to add some sort of "single-use-autocompletion" wherein the default exec command is faded but can be tabbed to completion