### PR TITLE
readme: update brew installation to use the official tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pacman -S ducker
 For macOS, you can install `ducker` using by `homebrew`.
 
 ```sh
-brew install draftbrew/tap/ducker
+brew install ducker
 ```
 
 ### Unstable


### PR DESCRIPTION
I have added `ducker` to the official homebrew core tap and so now the installation from official is more relevant.